### PR TITLE
Replace multiplication in 32-bit freduce_coefficients with shifts

### DIFF
--- a/curve25519-donna.c
+++ b/curve25519-donna.c
@@ -239,15 +239,18 @@ static void freduce_coefficients(limb *output) {
     output[10] = 0;
 
     for (i = 0; i < 10; i += 2) {
-      limb over = output[i] / 0x4000000l;
+      limb over = output[i] >> 26;
       output[i+1] += over;
-      output[i] -= over * 0x4000000l;
+      output[i] -= over << 26;
 
-      over = output[i+1] / 0x2000000;
+      over = output[i+1] >> 25;
       output[i+2] += over;
-      output[i+1] -= over * 0x2000000;
+      output[i+1] -= over << 25;
     }
-    output[0] += 19 * output[10];
+
+    output[0] += output[10] << 4;
+    output[0] += output[10] << 1;
+    output[0] += output[10];
   } while (output[10]);
 }
 


### PR DESCRIPTION
Bizarrely, when told to generate 32-bit code for multiplying an
int64_t by 0x400000l, gcc 4.6 (and probably earlier) generate code
that contains an imul and a mul instruction, when really it should
be able to do fine with shift instructions.  So just use explicit
shift operations instead.

Also, this patch use the same trick as in freduce_degree to make
the multiply-by-19 avoid 64-bit multiplication.

Together, these changes reduce the output of speed-curve25519-donna
from 1415us to 1118us on my core2 desktop.
