### PR TITLE
Another performance improvement for freduce_coefficients

### DIFF
--- a/curve25519-donna.c
+++ b/curve25519-donna.c
@@ -521,7 +521,8 @@ static void fmonty(limb *x2, limb *z2,  /* output 2Q */
   fdifference(zz, xx);  // does zz = xx - zz
   memset(zzz + 10, 0, sizeof(limb) * 9);
   fscalar_product(zzz, zz, 121665);
-  freduce_degree(zzz);
+  /* No need to call freduce_degree here:
+     fscalar_product doesn't increase the degree of its input. */
   freduce_coefficients(zzz);
   fsum(zzz, xx);
   fproduct(z2, zz, zzz);


### PR DESCRIPTION
This patch improved 32-bit performance by about another 13-14% for me.

The trick is to notice that our math all stays within bounds even its inputs are only "nearly reduced" (i.e., reduced coefficients +/- 1), and that 12 reduce operations are sufficient to put an unreduced value into "nearly reduced" form.  Previously, we were doing 20-30 reduce operations per call to freduce_coefficients.

Now, fcontract requires strictly reduced input, or else it produces the wrong value.  So the other trick is to notice that an extra call to freduce_coefficients will suffice to make the output strictly reduced.

See the commit message and comments in the code for full details.  
