### PR TITLE
Fix a gcc warning in speed-curve25519.c

### DIFF
--- a/speed-curve25519.c
+++ b/speed-curve25519.c
@@ -41,7 +41,7 @@ main() {
   }
   uint64_t end = time_now();
 
-  printf("%luus\n", (end - start) / 30000);
+  printf("%luus\n", (unsigned long) ((end - start) / 30000));
 
   return 0;
 }


### PR DESCRIPTION
Here's a small patch to fix a warning in speed-curve25519.c.

From the commit message:

It's not kosher to format a uint64_t with %lu: long is quite often
less than 64 bits wide.  Fortunately, the value that we want to format
here is the number of usec per operation, which won't brush up against
LONG_MAX unless you've pessimized the code until it takes over an hour
per call.
