### PR TITLE
run 'ranlib' on .a files, needed to make OS-X (10.6.8) happy

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -7,12 +7,14 @@ clean:
 
 curve25519-donna.a: curve25519-donna.o
 	ar -rc curve25519-donna.a curve25519-donna.o
+	ranlib curve25519-donna.a
 
 curve25519-donna.o: curve25519-donna.c
 	gcc -O2 -c curve25519-donna.c -Wall -m32 -ggdb
 
 curve25519-donna-c64.a: curve25519-donna-c64.o
 	ar -rc curve25519-donna-c64.a curve25519-donna-c64.o
+	ranlib curve25519-donna-c64.a
 
 curve25519-donna-c64.o: curve25519-donna-c64.c
 	gcc -O2 -c curve25519-donna-c64.c -Wall


### PR DESCRIPTION
Without it, I get an error when e.g. test-curve25519-donna attempts to link
against curve25519-donna.a built by Snow Leopard's gcc-4.2.1 (as mangled by
Apple):

  ld: in curve25519-donna.a, archive has no table of contents

I vaguely remember modern gcc/ar producing TOCs by default, so ranlib is
redundant these days, but this system's binutils are probably too old. I
believe ranlib is generally harmless on other systems.
