### PR TITLE
Remove the "wrong-length" printf from the python module.

### DIFF
--- a/python/curve25519module.c
+++ b/python/curve25519module.c
@@ -17,7 +17,6 @@ pycurve25519_makeprivate(PyObject *self, PyObject *args)
     if (!PyArg_ParseTuple(args, "t#:clamp", &in1, &in1len))
         return NULL;
     if (in1len != 32) {
-        printf("LEN is %ld\n", in1len);
         PyErr_SetString(PyExc_ValueError, "input must be 32-byte string");
         return NULL;
     }


### PR DESCRIPTION
Later pythons, or gcc, complained about a mismatch between
the %ld and the Py_ssize_t. The printf was really just there
for initial debugging anyways, so the simplest thing is to
remove it.
