### PR TITLE
Fix inline behavior/warnings under GCC 4.7

### DIFF
--- a/curve25519-donna-c64.c
+++ b/curve25519-donna-c64.c
@@ -36,7 +36,7 @@ typedef unsigned uint128_t __attribute__((mode(TI)));
 #define force_inline __attribute__((always_inline))
 
 /* Sum two numbers: output += in */
-static void force_inline
+static inline void force_inline
 fsum(limb *output, const limb *in) {
   output[0] += in[0];
   output[1] += in[1];
@@ -51,7 +51,7 @@ fsum(limb *output, const limb *in) {
  * Assumes that out[i] < 2**52
  * On return, out[i] < 2**55
  */
-static void force_inline
+static inline void force_inline
 fdifference_backwards(felem out, const felem in) {
   /* 152 is 19 << 3 */
   static const limb two54m152 = (((limb)1) << 54) - 152;
@@ -65,7 +65,7 @@ fdifference_backwards(felem out, const felem in) {
 }
 
 /* Multiply a number by a scalar: output = in * scalar */
-static void force_inline
+static inline void force_inline
 fscalar_product(felem output, const felem in, const limb scalar) {
   uint128_t a;
 
@@ -95,7 +95,7 @@ fscalar_product(felem output, const felem in, const limb scalar) {
  * Assumes that in[i] < 2**55 and likewise for in2.
  * On return, output[i] < 2**52
  */
-static void force_inline
+static inline void force_inline
 fmul(felem output, const felem in2, const felem in) {
   uint128_t t[5];
   limb r0,r1,r2,r3,r4,s0,s1,s2,s3,s4,c;
@@ -144,7 +144,7 @@ fmul(felem output, const felem in2, const felem in) {
   output[4] = r4;
 }
 
-static void force_inline
+static inline void force_inline
 fsquare_times(felem output, const felem in, limb count) {
   uint128_t t[5];
   limb r0,r1,r2,r3,r4,c;


### PR DESCRIPTION
When compiling under GCC 4.7 with -Wall, I get
   curve25519-donna-c64.c:148:1: warning: always_inline function
    might not be inlinable [-Wattributes](and so on for every always_inline function.)

A little research suggests that the always_inline attribute isn't
enough on its own: GCC also wants you to use the inline keyword.
Adding the inline keyword makes these warnings go away.
