### PR TITLE
Add an optimized curve25519_base_donna

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,8 +1,10 @@
 /curve25519-donna-c64.a
 /curve25519-donna.a
 /test-curve25519-donna
+/test-curve25519-donna-bp
 /speed-curve25519-donna
 /test-curve25519-donna-c64
+/test-curve25519-donna-bp-c64
 /speed-curve25519-donna-c64
 /test-sc-curve25519-donna-c64
 /build

--- a/Makefile
+++ b/Makefile
@@ -2,7 +2,7 @@ CFLAGS=-Wmissing-prototypes -Wdeclaration-after-statement -O2 -Wall
 
 targets: curve25519-donna.a curve25519-donna-c64.a
 
-test: test-donna test-donna-c64
+test: test-donna test-donna-c64 test-donna-bp test-donna-bp-c64
 
 clean:
 	rm -f *.o *.a *.pp test-curve25519-donna test-curve25519-donna-c64 speed-curve25519-donna speed-curve25519-donna-c64
@@ -27,11 +27,23 @@ test-donna: test-curve25519-donna
 test-donna-c64: test-curve25519-donna-c64
 	./test-curve25519-donna-c64 | head -123456 | tail -1
 
+test-donna-bp: test-curve25519-donna-bp
+	./test-curve25519-donna-bp | tail -1
+
+test-donna-bp-c64: test-curve25519-donna-bp-c64
+	./test-curve25519-donna-bp-c64 | tail -1
+
 test-curve25519-donna: test-curve25519.c curve25519-donna.a
 	gcc -o test-curve25519-donna test-curve25519.c curve25519-donna.a $(CFLAGS) -m32
 
 test-curve25519-donna-c64: test-curve25519.c curve25519-donna-c64.a
 	gcc -o test-curve25519-donna-c64 test-curve25519.c curve25519-donna-c64.a $(CFLAGS)
+
+test-curve25519-donna-bp: test-curve25519-bp.c curve25519-donna.a
+	gcc -o test-curve25519-donna-bp test-curve25519-bp.c curve25519-donna.a $(CFLAGS) -m32
+
+test-curve25519-donna-bp-c64: test-curve25519-bp.c curve25519-donna-c64.a
+	gcc -o test-curve25519-donna-bp-c64 test-curve25519-bp.c curve25519-donna-c64.a $(CFLAGS)
 
 speed-curve25519-donna: speed-curve25519.c curve25519-donna.a
 	gcc -o speed-curve25519-donna speed-curve25519.c curve25519-donna.a $(CFLAGS) -m32

--- a/curve25519-donna.c
+++ b/curve25519-donna.c
@@ -562,6 +562,58 @@ static void fmonty(limb *x2, limb *z2,  /* output 2Q */
   freduce_coefficients(z2);
 }
 
+/* As fmonty, but qpmp is always 9. */
+static void fmonty_bp(limb *x2, limb *z2,  /* output 2Q */
+                   limb *x3, limb *z3,  /* output Q + Q' */
+                   limb *x, limb *z,    /* input Q */
+                   limb *xprime, limb *zprime  /* input Q' */
+                      ) {
+  limb origx[10], origxprime[10], zzz[19], xx[19], zz[19], xxprime[19],
+        zzprime[19], zzzprime[19], xxxprime[19];
+
+  //  const limb nine[19] = {9};
+
+  memcpy(origx, x, 10 * sizeof(limb));
+  fsum(x, z);
+  fdifference(z, origx);  // does x - z
+
+  memcpy(origxprime, xprime, sizeof(limb) * 10);
+  fsum(xprime, zprime);
+  fdifference(zprime, origxprime);
+  fproduct(xxprime, xprime, z);
+  fproduct(zzprime, x, zprime);
+  freduce_degree(xxprime);
+  freduce_coefficients(xxprime);
+  freduce_degree(zzprime);
+  freduce_coefficients(zzprime);
+  memcpy(origxprime, xxprime, sizeof(limb) * 10);
+  fsum(xxprime, zzprime);
+  fdifference(zzprime, origxprime);
+  fsquare(xxxprime, xxprime);
+  fsquare(zzzprime, zzprime);
+  fscalar_product(zzprime, zzzprime, 9); /* Multiply by the basepoint */
+  freduce_coefficients(zzprime);
+
+  memcpy(x3, xxxprime, sizeof(limb) * 10);
+  memcpy(z3, zzprime, sizeof(limb) * 10);
+
+  fsquare(xx, x);
+  fsquare(zz, z);
+  fproduct(x2, xx, zz);
+  freduce_degree(x2);
+  freduce_coefficients(x2);
+  fdifference(zz, xx);  // does zz = xx - zz
+  memset(zzz + 10, 0, sizeof(limb) * 9);
+  fscalar_product(zzz, zz, 121665);
+  /* No need to call freduce_degree here:
+     fscalar_product doesn't increase the degree of its input. */
+  freduce_coefficients(zzz);
+  fsum(zzz, xx);
+  fproduct(z2, zz, zzz);
+  freduce_degree(z2);
+  freduce_coefficients(z2);
+}
+
 /* Conditionally swap two reduced-form limb arrays if 'iswap' is 1, but leave
  * them unchanged if 'iswap' is 0.  Runs in data-invariant time to avoid
  * side-channel attacks.
@@ -613,6 +665,56 @@ cmult(limb *resultx, limb *resultz, const u8 *n, const limb *q) {
              nqx, nqz,
              nqpqx, nqpqz,
              q);
+      swap_conditional(nqx2, nqpqx2, bit);
+      swap_conditional(nqz2, nqpqz2, bit);
+
+      t = nqx;
+      nqx = nqx2;
+      nqx2 = t;
+      t = nqz;
+      nqz = nqz2;
+      nqz2 = t;
+      t = nqpqx;
+      nqpqx = nqpqx2;
+      nqpqx2 = t;
+      t = nqpqz;
+      nqpqz = nqpqz2;
+      nqpqz2 = t;
+
+      byte <<= 1;
+    }
+  }
+
+  memcpy(resultx, nqx, sizeof(limb) * 10);
+  memcpy(resultz, nqz, sizeof(limb) * 10);
+}
+
+/* Calculates nQ where Q is the x-coordinate of a point on the curve
+ *
+ *   resultx/resultz: the x coordinate of the resulting curve point (short form)
+ *   n: a little endian, 32-byte number
+ *   q: a point of the curve (short form)
+ */
+static void
+cmult_bp(limb *resultx, limb *resultz, const u8 *n) {
+  limb a[19] = {9}, b[19] = {1}, c[19] = {1}, d[19] = {0};
+  limb *nqpqx = a, *nqpqz = b, *nqx = c, *nqz = d, *t;
+  limb e[19] = {0}, f[19] = {1}, g[19] = {0}, h[19] = {1};
+  limb *nqpqx2 = e, *nqpqz2 = f, *nqx2 = g, *nqz2 = h;
+
+  unsigned i, j;
+
+  for (i = 0; i < 32; ++i) {
+    u8 byte = n[31 - i];
+    for (j = 0; j < 8; ++j) {
+      const limb bit = byte >> 7;
+
+      swap_conditional(nqx, nqpqx, bit);
+      swap_conditional(nqz, nqpqz, bit);
+      fmonty_bp(nqx2, nqz2,
+             nqpqx2, nqpqz2,
+             nqx, nqz,
+             nqpqx, nqpqz);
       swap_conditional(nqx2, nqpqx2, bit);
       swap_conditional(nqz2, nqpqz2, bit);
 
@@ -722,6 +824,34 @@ curve25519_donna(u8 *mypublic, const u8 *secret, const u8 *basepoint) {
 
   fexpand(bp, basepoint);
   cmult(x, z, e, bp);
+  crecip(zmone, z);
+  fmul(z, x, zmone);
+  freduce_coefficients(z);
+  fcontract(mypublic, z);
+  return 0;
+}
+
+int curve25519_base_donna(u8 *, const u8 *);
+
+/* As curve25519_donna, but use the basepoint 9, to generate a public
+ * key from a secret key.
+ *
+ * This implementation is constant-time (in that it is independent of
+ * the value of 'secret') but it does *not* have the same runtime as
+ * computing "u8 bp[32] = {9}; curve25519_donna(mypublic, secret, bp);".
+ */
+int
+curve25519_base_donna(u8 *mypublic, const u8 *secret) {
+  limb x[10], z[11], zmone[10];
+  uint8_t e[32];
+  int i;
+
+  for (i = 0; i < 32; ++i) e[i] = secret[i];
+  e[0] &= 248;
+  e[31] &= 127;
+  e[31] |= 64;
+
+  cmult_bp(x, z, e);
   crecip(zmone, z);
   fmul(z, x, zmone);
   freduce_coefficients(z);

--- a/speed-curve25519.c
+++ b/speed-curve25519.c
@@ -7,6 +7,7 @@
 typedef uint8_t u8;
 
 extern void curve25519_donna(u8 *output, const u8 *secret, const u8 *bp);
+extern void curve25519_base_donna(u8 *output, const u8 *secret);
 
 static uint64_t
 time_now() {
@@ -41,6 +42,14 @@ main() {
   start = time_now();
   for (i = 0; i < 30000; ++i) {
     curve25519_donna(mypublic, mysecret, basepoint);
+  }
+  end = time_now();
+
+  printf("%luus\n", (unsigned long) ((end - start) / 30000));
+
+  start = time_now();
+  for (i = 0; i < 30000; ++i) {
+    curve25519_base_donna(mypublic, mysecret);
   }
   end = time_now();
 

--- a/test-curve25519-bp.c
+++ b/test-curve25519-bp.c
@@ -1,0 +1,32 @@
+
+#include <stdio.h>
+
+extern void curve25519_donna(unsigned char *output, const unsigned char *a,
+                             const unsigned char *b);
+
+extern void curve25519_base_donna(unsigned char *output, const unsigned char *a);
+
+int
+main()
+{
+  int i, loop;
+  unsigned char bp[32] = {9};
+  unsigned char x[32] = {3};
+  unsigned char y[32];
+  unsigned char y2[32];
+
+  for (loop = 0; loop < 1000; ++loop) {
+    curve25519_donna(y, x, bp);
+    curve25519_base_donna(y2, x);
+
+    for (i = 0;i < 32;++i) printf("%02x",(unsigned int) y[i]); printf(" ");
+    for (i = 0;i < 32;++i) printf("%02x",(unsigned int) y2[i]); printf("\n");
+
+    for (i=0; i<32; ++i) if (y[i] != y2[i]) {
+      printf("fail\n");
+      return 1;
+    }
+    for (i=0; i<32; ++i) x[i] ^= y[i];
+  }
+  return 0;
+}

--- a/test-curve25519.c
+++ b/test-curve25519.c
@@ -30,6 +30,8 @@ unsigned char e1[32] = {3};
 unsigned char e2[32] = {5};
 unsigned char k[32] = {9};
 
+const unsigned char bp[32] = {9};
+
 int
 main()
 {


### PR DESCRIPTION
In many protocols, it doesn't hurt security for a timing attacker to
know whether we're computing SK_9 ==> PUBKEY or whether we're
computing SK_PUBKEY ==> SHARED_SECRET.  For example, when you're doing
Diffie-Hellman, everybody will do one scalarmult of the basepoint (9),
and one scalarmult of the other party's public key.

For this kind of application, we can improve handshake speed by having
an optimized curve25519_base_donna function (name taken from nacl's
"crypto_scalarmult_base") that computes SK*BP.

Here I've only done the most obvious version of the optimization by
making an alternate fmonty_bp that does a scalar multiplication by 9
in place of fmul(.,.,qmqp).  On my laptop, the 64-bit
curve25519_base_donna is 11.5% faster than the regular 64-bit
curve25519_donna, and the 32-bit curve25519_base_donna is faster than
its counterpart by 4.7%.
