### PR TITLE
get_shared_public python function in Private class

### DIFF
--- a/python-src/curve25519/keys.py
+++ b/python-src/curve25519/keys.py
@@ -28,6 +28,15 @@ class Private:
     def get_public(self):
         return Public(_curve25519.make_public(self.private))
 
+    def get_shared_public(self, public):
+        """
+        Returns the established DH key as a Public instance.
+        """
+        if not isinstance(public, Public):
+            raise ValueError("'public' must be an instance of Public")
+        shared = _curve25519.make_shared(self.private, public.public)
+        return Public(shared)
+
     def get_shared_key(self, public, hashfunc=None):
         if not isinstance(public, Public):
             raise ValueError("'public' must be an instance of Public")


### PR DESCRIPTION
Some applications may need to obtain, from a public key g^x and a private key y, the shared secret as a group element g^xy, instead of getting directly the hashed value as method get_shared_key does. I added a very simple method to the Private python class that does this.
I am using your library for an implementation of the Sphinx mixnet protocol (Danezis, George, and Ian Goldberg. "Sphinx: A compact and provably secure mix format." Security and Privacy, 2009 30th IEEE Symposium on. IEEE, 2009), for which this functionality is needed. Please let me know if I can improve the code in any way.
Best
Daniele
