### PR TITLE
Recommend pubkey inclusion in key derivation

### DIFF
--- a/README
+++ b/README
@@ -23,7 +23,7 @@ USAGE:
 The usage is exactly the same as djb's code (as described at
 http://cr.yp.to/ecdh.html) expect that the function is called curve25519_donna.
 
-In short,
+In short:
 
 To generate a private key just generate 32 random bytes.
 
@@ -32,9 +32,10 @@ To generate the public key, just do:
   static const uint8_t basepoint[32] = {9};
   curve25519_donna(mypublic, mysecret, basepoint);
 
-To generate an agreed key do:
+To generate a shared secret do:
 
-  uint8_t shared_key[32];
-  curve25519_donna(shared_key, mysecret, theirpublic);
+  uint8_t shared[32];
+  curve25519_donna(shared, mysecret, theirpublic);
 
-And hash the shared_key with a cryptographic hash function before using.
+And hash the sender's public key, the recipient's public key, and shared_key
+with a cryptographic hash function before using.


### PR DESCRIPTION
Update README.md to suggest that users include the public keys of both
parties when deriving keys from the shared secret.

This is a common mistake by implementers -- and leads to quite serious
man-in-the-middle attacks -- so may as well suggest doing it right.